### PR TITLE
Soft lock fix on enemy collision

### DIFF
--- a/Assets/Scripts/DamageDealer.cs
+++ b/Assets/Scripts/DamageDealer.cs
@@ -11,8 +11,22 @@ public class DamageDealer : MonoBehaviour
         return damage;
     }
 
-    public void Hit()
+    public void Hit(GameObject target)
     {
+        Health targetHealth = target.GetComponent<Health>();
+        if (targetHealth != null)
+        {
+            // Apply damage to the target
+            targetHealth.TakeDamage(damage);
+
+            // Check if the target is the player and only destroy if health is zero
+            if (targetHealth.GetHealth() <= 0)
+            {
+                Destroy(target);
+            }
+        }
+
+        // Destroy the damage dealer itself, e.g., a projectile
         Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -21,7 +20,6 @@ public class Health : MonoBehaviour
     {
         return health;
     }
-    
 
     private void Awake()
     {
@@ -33,7 +31,6 @@ public class Health : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        
         DamageDealer damageDealer = other.GetComponent<DamageDealer>();
         if (damageDealer != null)
         {
@@ -41,24 +38,11 @@ public class Health : MonoBehaviour
             audioPlayer.PlayDamageClip();
             PlayHitEffect();
             ShakeCamera();
-            damageDealer.Hit();
-        }
-        PathFinder pathFinder = GetComponent<PathFinder>();
-        if (pathFinder != null)
-        {
-            if (pathFinder.checkAllEnemiesDestroyed())
-            {
-                Debug.Log("All enemies destroyed in wave!! congrats!");
-            }
-            else
-            {
-                Debug.Log(pathFinder.getNumOfEnemiesRemaining() + " more enemies to destroy");
-            }
-            
+            damageDealer.Hit(gameObject);
         }
     }
 
-    void TakeDamage(int damage)
+    public void TakeDamage(int damage)
     {
         health -= damage;
         if (health <= 0)


### PR DESCRIPTION
Updated Health and DamageDealer scripts so player is destroyed and game over is triggered on collision, to prevent soft lock